### PR TITLE
enable listing of only published course

### DIFF
--- a/controllers/userCourseControllers.ts
+++ b/controllers/userCourseControllers.ts
@@ -25,7 +25,7 @@ export const fetchCourses = async (
             limit = 5,
         } = req.query;
 
-        const filter: FilterQuery<ICourse> = {};
+        const filter: FilterQuery<ICourse> = { courseState: "published" };
 
         if (search) {
             filter.title = { $regex: search as string, $options: "i" };


### PR DESCRIPTION
This pull request includes a change to the `fetchCourses` function in the `controllers/userCourseControllers.ts` file. The change ensures that only courses with a `courseState` of "published" are fetched.

* [`controllers/userCourseControllers.ts`](diffhunk://#diff-1c835616c5e6e38f0e9156ed038bcb730570a5322d5a920d2483f80ac19bdb8cL28-R28): Modified the `filter` object to include `courseState: "published"` to ensure only published courses are retrieved.